### PR TITLE
Enhance usability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 0.0.3.pre (2018-10-29)
 ======================
 
-* [Breaking Change] Do not use enum parameter directory because the enums require upper camel case
-* [Enhancement] Rename additional_containers to sidecars (ecs_task.py operator)
+* [Breaking Change] Do not use enum parameter directory because the enums require upper camel case ( `ecs_task.{py,register,run}>` operator)
+* [Enhancement] Rename the configuration key: `additional_containers` to `sidecars` ( `ecs_task.py>` operator)
+* [Enhancement] Rename the configuration key: `environment` to `environments` ( `ecs_task.py>` operator)
+* [Enhancement] Rename the output key: `last_ecs_task_py` to `last_ecs_task_command` ( `ecs_task.py>` operator)
 * [Fix] Fix example indents
 
 0.0.2 (2018-10-29)

--- a/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/command/EcsTaskCommandResultInternalOperator.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/command/EcsTaskCommandResultInternalOperator.scala
@@ -36,7 +36,7 @@ class EcsTaskCommandResultInternalOperator(operatorName: String, context: Operat
       .storeParams(
         out
           .getNestedOrGetEmpty("store_params")
-          .setNested("last_ecs_task_py", statusParams)
+          .setNested("last_ecs_task_command", statusParams)
       )
       .build()
   }

--- a/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/command/EcsTaskCommandRunner.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/command/EcsTaskCommandRunner.scala
@@ -41,7 +41,7 @@ case class EcsTaskCommandRunner(params: Config, environments: Map[String, String
   val dockerSecurityOptions: Seq[String] = params.getListOrEmpty("docker_security_options", classOf[String]).asScala
   val entryPoint: Seq[String] = params.getListOrEmpty("entry_point", classOf[String]).asScala
   // NOTE: Add some envs by this plugin
-  val configEnvironment: Map[String, String] = params.getMapOrEmpty("environment", classOf[String], classOf[String]).asScala.toMap
+  val configEnvironment: Map[String, String] = params.getMapOrEmpty("environments", classOf[String], classOf[String]).asScala.toMap
   // NOTE: This plugin uses only 1 container so `essential` is always true.
   // val essential: Optional[Boolean] = params.getOptional("essential", classOf[Boolean])
   val extraHosts: Map[String, String] = params.getMapOrEmpty("extra_hosts", classOf[String], classOf[String]).asScala.toMap


### PR DESCRIPTION
* [Enhancement] Rename the configuration key: `environment` to `environments` ( `ecs_task.py>` operator)
* [Enhancement] Rename the output key: `last_ecs_task_py` to `last_ecs_task_command` ( `ecs_task.py>` operator)