### PR TITLE
Change the config key name: environment to environments ( `ecs_task.run>` operator)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 * [Breaking Change] Do not use enum parameter directory because the enums require upper camel case ( `ecs_task.{py,register,run}>` operator)
 * [Enhancement] Rename the configuration key: `additional_containers` to `sidecars` ( `ecs_task.py>` operator)
-* [Enhancement] Rename the configuration key: `environment` to `environments` ( `ecs_task.py>` operator)
+* [Enhancement] Rename the configuration key: `environment` to `environments` ( `ecs_task.{py,run}>` operator)
 * [Enhancement] Rename the output key: `last_ecs_task_py` to `last_ecs_task_command` ( `ecs_task.py>` operator)
 * [Fix] Fix example indents
 

--- a/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/run/EcsTaskRunInternalOperator.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/run/EcsTaskRunInternalOperator.scala
@@ -102,8 +102,8 @@ class EcsTaskRunInternalOperator(operatorName: String, context: OperatorContext,
 
     val command: Seq[String] = c.getListOrEmpty("command", classOf[String]).asScala
     val cpu: Optional[Int] = c.getOptional("cpu", classOf[Int])
-    val environment: Seq[KeyValuePair] = c
-      .getMapOrEmpty("environment", classOf[String], classOf[String])
+    val environments: Seq[KeyValuePair] = c
+      .getMapOrEmpty("environments", classOf[String], classOf[String])
       .asScala
       .map { case (k: String, v: String) => new KeyValuePair().withName(k).withValue(v) }
       .toSeq // TODO: doc
@@ -114,7 +114,7 @@ class EcsTaskRunInternalOperator(operatorName: String, context: OperatorContext,
     val co: ContainerOverride = new ContainerOverride()
     if (command.nonEmpty) co.setCommand(command.asJava)
     if (cpu.isPresent) co.setCpu(cpu.get)
-    if (environment.nonEmpty) co.setEnvironment(environment.asJava)
+    if (environments.nonEmpty) co.setEnvironment(environments.asJava)
     if (memory.isPresent) co.setMemory(memory.get)
     if (memoryReservation.isPresent) co.setMemoryReservation(memoryReservation.get)
     if (name.isPresent) co.setName(name.get)


### PR DESCRIPTION
* [Enhancement] Rename the configuration key: `environment` to `environments` ( `ecs_task.{py,run}>` operator)