### PR TITLE
Change the config key name: environment to environments ( `ecs_task.register>` operator)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 * [Breaking Change] Do not use enum parameter directory because the enums require upper camel case ( `ecs_task.{py,register,run}>` operator)
 * [Enhancement] Rename the configuration key: `additional_containers` to `sidecars` ( `ecs_task.py>` operator)
-* [Enhancement] Rename the configuration key: `environment` to `environments` ( `ecs_task.{py,run}>` operator)
+* [Breaking Change/Enhancement] Rename the configuration key: `environment` to `environments` ( `ecs_task.{py,register,run}>` operator)
 * [Enhancement] Rename the output key: `last_ecs_task_py` to `last_ecs_task_command` ( `ecs_task.py>` operator)
 * [Fix] Fix example indents
 

--- a/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/register/EcsTaskRegisterOperator.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/register/EcsTaskRegisterOperator.scala
@@ -77,8 +77,8 @@ class EcsTaskRegisterOperator(operatorName: String, context: OperatorContext, sy
     val dockerLabels: Map[String, String] = c.getMapOrEmpty("docker_labels", classOf[String], classOf[String]).asScala.toMap
     val dockerSecurityOptions: Seq[String] = c.getListOrEmpty("docker_security_options", classOf[String]).asScala
     val entryPoint: Seq[String] = c.getListOrEmpty("entry_point", classOf[String]).asScala
-    val environment: Seq[KeyValuePair] = c
-      .getMapOrEmpty("environment", classOf[String], classOf[String])
+    val environments: Seq[KeyValuePair] = c
+      .getMapOrEmpty("environments", classOf[String], classOf[String])
       .asScala
       .map { case (k: String, v: String) => new KeyValuePair().withName(k).withValue(v) }
       .toSeq // TODO: doc
@@ -119,7 +119,7 @@ class EcsTaskRegisterOperator(operatorName: String, context: OperatorContext, sy
     if (dockerLabels.nonEmpty) cd.setDockerLabels(dockerLabels.asJava)
     if (dockerSecurityOptions.nonEmpty) cd.setDockerSecurityOptions(dockerSecurityOptions.asJava)
     if (entryPoint.nonEmpty) cd.setEntryPoint(entryPoint.asJava)
-    if (environment.nonEmpty) cd.setEnvironment(environment.asJava) // TODO: merge params?
+    if (environments.nonEmpty) cd.setEnvironment(environments.asJava) // TODO: merge params?
     if (essential.isPresent) cd.setEssential(essential.get)
     if (extraHosts.nonEmpty) cd.setExtraHosts(extraHosts.asJava)
     if (healthCheck.isPresent) cd.setHealthCheck(healthCheck.get)


### PR DESCRIPTION
* [Breaking Change/Enhancement] Rename the configuration key: `environment` to `environments` ( `ecs_task.{py,register,run}>` operator)