### PR TITLE
Ship v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-0.0.3.pre (2018-10-29)
+0.0.3 (2018-10-30)
 ======================
 
 * [Breaking Change] Do not use enum parameter directory because the enums require upper camel case ( `ecs_task.{py,register,run}>` operator)
@@ -6,6 +6,12 @@
 * [Breaking Change/Enhancement] Rename the configuration key: `environment` to `environments` ( `ecs_task.{py,register,run}>` operator)
 * [Enhancement] Rename the output key: `last_ecs_task_py` to `last_ecs_task_command` ( `ecs_task.py>` operator)
 * [Fix] Fix example indents
+* [Fix] Avoid java.nio.charset.MalformedInputException: Input length = 1
+* [Fix] Avoid com.amazonaws.services.ecs.model.ClientException: Family contains invalid characters when the default value is used.
+* [Enhancement] Enable to parse json text in configuration
+* [Enhancement] Get s3 content more simply
+* [Fix] Use unique s3 workspace path
+* [Fix] print error in runner.py
 
 0.0.2 (2018-10-29)
 ==================

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _export:
     repositories:
       - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-ecs_task:0.0.2
+      - pro.civitaspo:digdag-operator-ecs_task:0.0.3
   ecs_task:
     auth_method: profile
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'pro.civitaspo'
-version = '0.0.3.pre'
+version = '0.0.3'
 
 def digdagVersion = '0.9.31'
 def scalaSemanticVersion = "2.12.6"

--- a/example/example.dig
+++ b/example/example.dig
@@ -4,7 +4,7 @@ _export:
       - file://${repos}
       # - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-ecs_task:0.0.3.pre
+      - pro.civitaspo:digdag-operator-ecs_task:0.0.3
   ecs_task:
     auth_method: profile
 

--- a/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/command/EcsTaskCommandRunner.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/command/EcsTaskCommandRunner.scala
@@ -187,7 +187,7 @@ case class EcsTaskCommandRunner(params: Config, environments: Map[String, String
     c.setOptional("disable_networking", disableNetworking)
     c.set("dns_search_domains", dnsSearchDomains.asJava)
     c.set("dns_servers", dnsServers.asJava)
-    val additionalLabels: Map[String, String] = Map("pro.civitaspo.digdag.plugin.ecs_task.version" -> "0.0.3.pre")
+    val additionalLabels: Map[String, String] = Map("pro.civitaspo.digdag.plugin.ecs_task.version" -> "0.0.3")
     c.set("docker_labels", (dockerLabels ++ additionalLabels).asJava)
     c.set("entry_point", entryPoint.asJava)
     c.set("environment", (configEnvironment ++ environments).asJava)


### PR DESCRIPTION
* [Breaking Change] Do not use enum parameter directory because the enums require upper camel case ( `ecs_task.{py,register,run}>` operator)
* [Enhancement] Rename the configuration key: `additional_containers` to `sidecars` ( `ecs_task.py>` operator)
* [Breaking Change/Enhancement] Rename the configuration key: `environment` to `environments` ( `ecs_task.{py,register,run}>` operator)
* [Enhancement] Rename the output key: `last_ecs_task_py` to `last_ecs_task_command` ( `ecs_task.py>` operator)
* [Fix] Fix example indents
* [Fix] Avoid java.nio.charset.MalformedInputException: Input length = 1
* [Fix] Avoid com.amazonaws.services.ecs.model.ClientException: Family contains invalid characters when the default value is used.
* [Enhancement] Enable to parse json text in configuration
* [Enhancement] Get s3 content more simply
* [Fix] Use unique s3 workspace path
* [Fix] print error in runner.py