### PR TITLE
Ship v0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+0.0.5 (2018-11-13)
+==================
+
+* [Experimental] Implement `ecs_task.rb>` operator.
+* [Experimental] Implement `ecs_task.sh>` operator.
+* [Enhancement] Add interface for another storage except S3 used by scripting operators.
+* [Enhancement] Add abstract class for scripting operators.
+* [Enhancement] Request ECS TaskRun with some retry.
+* [Fix] Prevent the influence of prior task registration.
+* [Enhancement] Add Logging for registered TaskDefinition arn. 
+* [Enhancement] Define VERSION var as package object val.
+
 0.0.4 (2018-11-06)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _export:
     repositories:
       - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-ecs_task:0.0.4
+      - pro.civitaspo:digdag-operator-ecs_task:0.0.5
   ecs_task:
     auth_method: profile
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'pro.civitaspo'
-version = '0.0.4'
+version = '0.0.5'
 
 def digdagVersion = '0.9.31'
 def scalaSemanticVersion = "2.12.6"

--- a/example/example.dig
+++ b/example/example.dig
@@ -4,7 +4,7 @@ _export:
       - file://${repos}
       # - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-ecs_task:0.0.4
+      - pro.civitaspo:digdag-operator-ecs_task:0.0.5
   ecs_task:
     auth_method: profile
 

--- a/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/package.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/package.scala
@@ -2,6 +2,6 @@ package pro.civitaspo.digdag.plugin
 
 package object ecs_task {
 
-  val VERSION: String = "0.0.4"
+  val VERSION: String = "0.0.5"
 
 }


### PR DESCRIPTION
* [Experimental] Implement `ecs_task.rb>` operator.
* [Experimental] Implement `ecs_task.sh>` operator.
* [Enhancement] Add interface for another storage except S3 used by scripting operators.
* [Enhancement] Add abstract class for scripting operators.
* [Enhancement] Request ECS TaskRun with some retry.
* [Fix] Prevent the influence of prior task registration.
* [Enhancement] Add Logging for registered TaskDefinition arn. 
* [Enhancement] Define VERSION var as package object val.