### PR TITLE
Rel/v0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.0.7 (2018-11-19)
+==================
+
+* [Enhancement] Add examples for scripting operators and update `ecs_task.run>` example.
+* [Enhancement] Always normalize ECS Task family name.
+* [Enhancement] Update aws-java-sdk 1.11.433 -> 1.11.451
+* [Enhancement] Add new options (`secrets`, `tags`) that follow ECS new release. `ipc_mode` and `pid_mode` are not supported yet because aws-java-sdk does not supports them.
+
 0.0.6 (2018-11-13)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _export:
     repositories:
       - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-ecs_task:0.0.6
+      - pro.civitaspo:digdag-operator-ecs_task:0.0.7
   ecs_task:
     auth_method: profile
     tmp_storage:

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'pro.civitaspo'
-version = '0.0.6'
+version = '0.0.7'
 
 def digdagVersion = '0.9.31'
 def scalaSemanticVersion = "2.12.6"

--- a/example/example.dig
+++ b/example/example.dig
@@ -4,7 +4,7 @@ _export:
       - file://${repos}
       # - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-ecs_task:0.0.6
+      - pro.civitaspo:digdag-operator-ecs_task:0.0.7
   ecs_task:
     auth_method: profile
     tmp_storage:

--- a/example/template.txt
+++ b/example/template.txt
@@ -1,1 +1,0 @@
-Worked? ${message}

--- a/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/command/AbstractEcsTaskCommandOperator.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/command/AbstractEcsTaskCommandOperator.scala
@@ -56,7 +56,7 @@ abstract class AbstractEcsTaskCommandOperator(operatorName: String, context: Ope
   protected def collectEnvironments(): Map[String, String] = {
     val vars: PrivilegedVariables = context.getPrivilegedVariables
     vars.getKeys.asScala.foldLeft(Map.empty[String, String]) { (env, key) =>
-    if (isValidEnvKey(key)) {
+      if (isValidEnvKey(key)) {
         env ++ Map(key -> vars.get(key))
       }
       else {

--- a/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/command/EcsTaskCommandRunner.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/command/EcsTaskCommandRunner.scala
@@ -74,7 +74,7 @@ case class EcsTaskCommandRunner(
   // NOTE: If you set it by container level, use the `overrides` option.
   // val memoryReservation: Optional[Int] = params.getOptional("memory_reservation", classOf[Int])
   val mountPoints: Seq[Config] = params.parseListOrGetEmpty("mount_points", classOf[Config]).asScala
-  val containerName: Optional[String]= params.getOptional("container_name", classOf[String])
+  val containerName: Optional[String] = params.getOptional("container_name", classOf[String])
   val portMappings: Seq[Config] = params.parseListOrGetEmpty("port_mappings", classOf[Config]).asScala
   val privileged: Optional[Boolean] = params.getOptional("privileged", classOf[Boolean])
   val pseudoTerminal: Optional[Boolean] = params.getOptional("pseudo_terminal", classOf[Boolean])
@@ -235,7 +235,7 @@ case class EcsTaskCommandRunner(
   protected def normalizeFamily(family: String): String = {
     // ref. https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RegisterTaskDefinition.html#ECS-RegisterTaskDefinition-request-family
     val validLetterRegex: Regex = "[a-zA-Z0-9_-]".r
-    val after: String = family.map{ case l @ validLetterRegex() => l; case _ => "_" }.mkString
+    val after: String = family.map { case l @ validLetterRegex() => l; case _ => "_" }.mkString
     if (!family.contentEquals(after)) logger.warn(s"Normalized family: $family -> $after")
     after
   }

--- a/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/package.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/package.scala
@@ -2,6 +2,6 @@ package pro.civitaspo.digdag.plugin
 
 package object ecs_task {
 
-  val VERSION: String = "0.0.6"
+  val VERSION: String = "0.0.7"
 
 }


### PR DESCRIPTION
* [Enhancement] Add examples for scripting operators and update `ecs_task.run>` example.
* [Enhancement] Always normalize ECS Task family name.
* [Enhancement] Update aws-java-sdk 1.11.433 -> 1.11.451
* [Enhancement] Add new options (`secrets`, `tags`) that follow ECS new release. `ipc_mode` and `pid_mode` are not supported yet because aws-java-sdk does not supports them.