### PR TITLE
Retry scripting operator when the container exit without exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ In addition, the below configurations exist.
 
 ## Scripting Operators Common Configurations
 
+- **max_retry**: Max number of retry when scripting container has no exit code. (integer, default: `3`)
 - **sidecars**: A list of container definitions except the container for scripting operator. (array of map, optional)
     - The configuration map is the same as the snake-cased [API_ContainerDefinition](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html)
 - **cpu**: The number of CPU units used by the task. It can be expressed as an integer using CPU units, for example `1024`, or as a string using vCPUs, for example `1 vCPU` or `1 vcpu`, in a task definition. String values are converted to an integer indicating the CPU units when the task definition is registered. (string, optional)

--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ In addition, the below configurations exist.
 - **timeout**: Timeout duration for the tasks. (`DurationParam`, default: `15m`)
 - **condition**: The condition of tasks to wait. Available values are `"all"` or `"any"`. (string, default: `"all"`)
 - **status**: The status of tasks to wait. Available values are `"PENDING"`, `"RUNNING"`, or `"STOPPED"` (string, default: `"STOPPED"`)
-- **ignore_failure**: Ignore even if any tasks exit with the code except 0. (boolean, default: `false`) 
+- **ignore_failure**: Ignore even if any tasks exit with any status. This option is true, then the behaviour includes one of when **ignore_exit_code** is `true`. (boolean, default: `false`)
+- **ignore_exit_code**: Ignore even if any tasks exit with any exit code. When the containers of the task include one that does not have exit code, it is not ignored even if this option is `true`. (boolean, default: `false`) 
 
 ## Configuration for `ecs_task.result>` operator
 

--- a/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/EcsTaskPlugin.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/EcsTaskPlugin.scala
@@ -6,7 +6,7 @@ import java.util.{Arrays => JArrays, List => JList}
 import io.digdag.client.config.Config
 import io.digdag.spi.{Operator, OperatorContext, OperatorFactory, OperatorProvider, Plugin, TemplateEngine}
 import javax.inject.Inject
-import pro.civitaspo.digdag.plugin.ecs_task.command.EcsTaskCommandResultInternalOperator
+import pro.civitaspo.digdag.plugin.ecs_task.command.{EcsTaskCallInternalOperator, EcsTaskCommandResultInternalOperator}
 import pro.civitaspo.digdag.plugin.ecs_task.embulk.EcsTaskEmbulkOperator
 import pro.civitaspo.digdag.plugin.ecs_task.py.EcsTaskPyOperator
 import pro.civitaspo.digdag.plugin.ecs_task.rb.EcsTaskRbOperator
@@ -29,6 +29,7 @@ object EcsTaskPlugin {
         operatorFactory("ecs_task.py", classOf[EcsTaskPyOperator]),
         operatorFactory("ecs_task.rb", classOf[EcsTaskRbOperator]),
         operatorFactory("ecs_task.sh", classOf[EcsTaskShOperotar]),
+        operatorFactory("ecs_task.call_internal", classOf[EcsTaskCallInternalOperator]),
         operatorFactory("ecs_task.command_result_internal", classOf[EcsTaskCommandResultInternalOperator]),
         operatorFactory("ecs_task.register", classOf[EcsTaskRegisterOperator]),
         operatorFactory("ecs_task.result", classOf[EcsTaskResultOperator]),

--- a/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/command/EcsTaskCallInternalOperator.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/command/EcsTaskCallInternalOperator.scala
@@ -1,0 +1,15 @@
+package pro.civitaspo.digdag.plugin.ecs_task.command
+import io.digdag.client.config.Config
+import io.digdag.spi.{OperatorContext, TaskResult, TemplateEngine}
+import pro.civitaspo.digdag.plugin.ecs_task.AbstractEcsTaskOperator
+
+class EcsTaskCallInternalOperator(operatorName: String, context: OperatorContext, systemConfig: Config, templateEngine: TemplateEngine)
+  extends AbstractEcsTaskOperator(operatorName, context, systemConfig, templateEngine) {
+
+  protected val doConfig: Config = params.getNested("_do")
+
+  override def runTask(): TaskResult = {
+    TaskResult.defaultBuilder(cf).subtaskConfig(doConfig).build()
+  }
+
+}

--- a/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/wait/EcsTaskWaitOperator.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/wait/EcsTaskWaitOperator.scala
@@ -40,13 +40,14 @@ class EcsTaskWaitOperator(operatorName: String, context: OperatorContext, system
       task.getContainers.asScala.foreach { container =>
         Option(container.getExitCode) match {
           case Some(code) =>
-            val msg = s"[${task.getTaskArn}] ${container.getName} has stopped with exit_code=$code"
-            logger.info(msg)
-            if (!code.equals(0)) failedMessages += msg
+            val message = s"[${task.getTaskArn}] ${container.getName} has stopped with exit_code=$code"
+            logger.info(message)
+            if (!code.equals(0)) failedMessages += message
           case None =>
-            val msg = s"[${task.getTaskArn}] ${container.getName} has stopped without exit_code: reason=${container.getReason}"
-            logger.info(msg)
-            failedMessages += msg
+            val message =
+              s"[${task.getTaskArn}] ${container.getName} has stopped without exit_code: reason=${container.getReason}, task_stopped_reason=${task.getStoppedReason}"
+            logger.info(message)
+            failedMessages += message
         }
       }
     }


### PR DESCRIPTION
* Add `ignore_exit_code` option to `ecs_task.wait>` operator.
* Scripting operators use `ignore_exit_code` instead of `ignore_failure` for the retries when the container exit without exit code.
* Implement `ecs_task.call_internal>` operator as a workaround for the issue: https://github.com/treasure-data/digdag/issues/849