### PR TITLE
Ship v0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.0.13 (2019-07-30)
+===================
+* [Fix] Fix environments bug: no environments in scripting operators
+* [Fix] Catch any initialization exception and re-throw as `ConfigException`
+
 0.0.12 (2019-05-23)
 ===================
 * [Enhancement] Follow latest python runner script used by `ecs_task.py>`. The changes resolve the same issues that the bellow p-rs resolve.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _export:
     repositories:
       - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-ecs_task:0.0.12
+      - pro.civitaspo:digdag-operator-ecs_task:0.0.13
   ecs_task:
     auth_method: profile
     tmp_storage:

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'pro.civitaspo'
-version = '0.0.12'
+version = '0.0.13'
 
 def digdagVersion = '0.9.31'
 def scalaSemanticVersion = "2.12.6"

--- a/example/example.dig
+++ b/example/example.dig
@@ -4,7 +4,7 @@ _export:
       - file://${repos}
       # - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-ecs_task:0.0.12
+      - pro.civitaspo:digdag-operator-ecs_task:0.0.13
   ecs_task:
     auth_method: profile
     tmp_storage:

--- a/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/package.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/package.scala
@@ -2,6 +2,6 @@ package pro.civitaspo.digdag.plugin
 
 package object ecs_task {
 
-  val VERSION: String = "0.0.12"
+  val VERSION: String = "0.0.13"
 
 }


### PR DESCRIPTION
* [Fix] Fix environments bug: no environments in scripting operators
* [Fix] Catch any initialization exception and re-throw as `ConfigException`