### PR TITLE
Ship v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+0.1.0 (2019-12-08)
+==================
+* [Enhancement] Update dependencies (digdag 0.9.31 -> 0.9.41, scala 2.12.6 -> 2.13.1, aws-sdk 1.11.451 -> 1.11.751)
+* [Enhancement] Add test dependencies
+* [Enhancement] Apply Scala 2.13 style
+* [Enhancement] Use `scala.jdk.CollectionConverters._` instead of `scala.collection.JavaConverters._`
+* [Enhancement] Fix deprecations by Scala 2.13
+* [Enhancement] Use Using.resource instead of TryWithResource
+* [New Feature] Use Github Actions instead of CircleCI
+* [New Feature] Release to Github Packages when tagging
+* [Enhancement] Update spotless 3.13.0 -> 3.27.1
+* [Enhancement] Update scalafmt 1.5.1 -> 2.3.2
+
 0.0.14 (2019-11-24)
 ===================
 * [Enhancement] Add `shell` option to change the shell command that the operator uses internally.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _export:
     repositories:
       - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-ecs_task:0.0.14
+      - pro.civitaspo:digdag-operator-ecs_task:0.1.0
   ecs_task:
     auth_method: profile
     tmp_storage:

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'pro.civitaspo'
-version = '0.0.14'
+version = '0.1.0'
 
 def digdagVersion = '0.9.41'
 def scalaSemanticVersion = "2.13.1"

--- a/example/example.dig
+++ b/example/example.dig
@@ -4,7 +4,7 @@ _export:
       - file://${repos}
       # - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-ecs_task:0.0.14
+      - pro.civitaspo:digdag-operator-ecs_task:0.1.0
   ecs_task:
     auth_method: profile
     tmp_storage:

--- a/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/package.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/package.scala
@@ -2,6 +2,6 @@ package pro.civitaspo.digdag.plugin
 
 package object ecs_task {
 
-  val VERSION: String = "0.0.14"
+  val VERSION: String = "0.1.0"
 
 }


### PR DESCRIPTION
* [Enhancement] Update dependencies (digdag 0.9.31 -> 0.9.41, scala 2.12.6 -> 2.13.1, aws-sdk 1.11.451 -> 1.11.751)
* [Enhancement] Add test dependencies
* [Enhancement] Apply Scala 2.13 style
* [Enhancement] Use `scala.jdk.CollectionConverters._` instead of `scala.collection.JavaConverters._`
* [Enhancement] Fix deprecations by Scala 2.13
* [Enhancement] Use Using.resource instead of TryWithResource
* [New Feature] Use Github Actions instead of CircleCI
* [New Feature] Release to Github Packages when tagging
* [Enhancement] Update spotless 3.13.0 -> 3.27.1
* [Enhancement] Update scalafmt 1.5.1 -> 2.3.2
