### PR TITLE
Ship v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.1.1 (2020-05-22)
+==================
+* [New Feature] [#71](https://github.com/civitaspo/digdag-operator-ecs_task/pull/71) Support a new log driver: `awsfirelens`.
+
 0.1.0 (2019-12-08)
 ==================
 * [Enhancement] Update dependencies (digdag 0.9.31 -> 0.9.41, scala 2.12.6 -> 2.13.1, aws-sdk 1.11.451 -> 1.11.751)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _export:
     repositories:
       - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-ecs_task:0.1.0
+      - pro.civitaspo:digdag-operator-ecs_task:0.1.1
   ecs_task:
     auth_method: profile
     tmp_storage:

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'pro.civitaspo'
-version = '0.1.0'
+version = '0.1.1'
 
 def digdagVersion = '0.9.41'
 def scalaSemanticVersion = "2.13.1"

--- a/example/example.dig
+++ b/example/example.dig
@@ -4,7 +4,7 @@ _export:
       - file://${repos}
       # - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-ecs_task:0.1.0
+      - pro.civitaspo:digdag-operator-ecs_task:0.1.1
   ecs_task:
     auth_method: profile
     tmp_storage:

--- a/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/package.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/ecs_task/package.scala
@@ -2,6 +2,6 @@ package pro.civitaspo.digdag.plugin
 
 package object ecs_task {
 
-  val VERSION: String = "0.1.0"
+  val VERSION: String = "0.1.1"
 
 }


### PR DESCRIPTION
0.1.1 (2020-05-22)
==================
* [New Feature] [#71](https://github.com/civitaspo/digdag-operator-ecs_task/pull/71) Support a new log driver: `awsfirelens`.