### PR TITLE
Add support for EFS volume configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
     ['ecs', 's3', 'sts'].each { svc ->
         // https://mvnrepository.com/artifact/com.amazonaws/
-        compile group: 'com.amazonaws', name: "aws-java-sdk-${svc}", version: '1.11.751'
+        compile group: 'com.amazonaws', name: "aws-java-sdk-${svc}", version: '1.11.930'
     }
 
     testCompile group: 'org.scalatest', name: "scalatest_$depScalaVersion", version: '3.0.8'


### PR DESCRIPTION
Added support for EFS volume configuration in ECS task definition. Had to upgrade `aws-sdk` since `EFS*` models were not available in `1.11.751`.