### PR TITLE
Install from maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,6 @@ def depScalaVersion = "2.13"
 
 repositories {
     mavenCentral()
-    jcenter()
-    maven {
-        url 'https://dl.bintray.com/digdag/maven'
-    }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 group = 'pro.civitaspo'
 version = '0.1.3'
 
-def digdagVersion = '0.9.41'
+def digdagVersion = '0.9.42'
 def scalaSemanticVersion = "2.13.1"
 def depScalaVersion = "2.13"
 


### PR DESCRIPTION
* Use maven instead of bintray.
* For digdag, only 0.9.42 is hosted on maven for the 0.9.X.